### PR TITLE
Updated ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.5.1-node-browsers
+FROM circleci/ruby:2.6.3-node-browsers
 MAINTAINER Atsushi Nagase<ngs@hiinc.jp>
 
 ENV PHANTOMJS_VERSION 2.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN curl --location --silent https://bitbucket.org/ariya/phantomjs/downloads/pha
 RUN sudo apt-get install -y fonts-migmix
 RUN sudo npm install -g jshint
 RUN sudo gem update --system 2.7.4 # https://git.io/vAB1b
-RUN sudo gem install bundler --no-rdoc --no-ri
+RUN sudo gem install bundler --no-rdoc --no-ri --force


### PR DESCRIPTION
CAMPFIRE 本体の Ruby のバージョンを 2.6.3 にアップデートしたい為、Docker コンテナの Ruby バージョンをアップデートをする。

docker build できることは確認済み。

マージ後、CAMPFIRE の方で latest を指定する

## 外部リンク
force オプションをつけた背景: https://yoshinorin.net/2017/11/27/bundle-from-bundler-conflicts/